### PR TITLE
UI-3113: DateTime field space is not calculated correctly when default value MM/DD/YY

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@ v3.2.4
 ==================
 * Fixed DateTime field spacing issue when default value MM/DD/YY on Edge and Firefox.
 
-v3.3.3
+v3.2.3
 ==================
 * Fixed regression in px-icon sizes.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v3.2.4
+==================
+* Fixed DateTime field spacing issue when default value MM/DD/YY on Edge and Firefox.
+
 v3.3.3
 ==================
 * Fixed regression in px-icon sizes.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-datetime-common",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "main": [
     "px-datetime-common.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-datetime-common",
   "author": "General Electric",
   "description": "A Px component",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -246,12 +246,13 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
       }
       ctx.font = fontSize + " " + fontFamily;
       if(this.$$('.datetime-entry-input').value) {
-        length = ctx.measureText(this.$$('.datetime-entry-input').value.toUpperCase()).width + 1;
+        length = ctx.measureText(this.$$('.datetime-entry-input').value.toUpperCase()).width;
       }
       else {
         length = ctx.measureText(this.$$('.datetime-entry-input').placeholder).width;
       }
-      length = Math.ceil(length);
+      // input doesn't have enough spacing on Edge and Firefox for value & placeholder text
+      length = Math.ceil(length) + 2;
       this.$$('.datetime-entry-input').style['width'] = length + 'px';
     },
     /**

--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -246,13 +246,13 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
       }
       ctx.font = fontSize + " " + fontFamily;
       if(this.$$('.datetime-entry-input').value) {
-        length = ctx.measureText(this.$$('.datetime-entry-input').value.toUpperCase()).width;
+        length = ctx.measureText(this.$$('.datetime-entry-input').value.toUpperCase()).width + 1;
       }
       else {
-        length = ctx.measureText(this.$$('.datetime-entry-input').placeholder).width;
+        // the extra width is needed for the placeholder ONLY on Edge and Firefox
+        length = ctx.measureText(this.$$('.datetime-entry-input').placeholder).width + 2;
       }
-      // input doesn't have enough spacing on Edge and Firefox for value & placeholder text
-      length = Math.ceil(length) + 2;
+      length = Math.ceil(length);
       this.$$('.datetime-entry-input').style['width'] = length + 'px';
     },
     /**

--- a/test/px-datetime-entry-tests.js
+++ b/test/px-datetime-entry-tests.js
@@ -1016,7 +1016,8 @@ suite('px-datetime-entry-cell empty', function () {
     MockInteractions.pressAndReleaseKeyOn(cells[0], 40, [], 'ArrowDown');
 
     expect(theInput[0].value)
-      .to.eventuallyEqual('59', {within: 1000, every: 100}, done);
+      .to.eventuallyEqual('59', {within: 1000, every: 100});
+      done();
     });
   });
 


### PR DESCRIPTION
- Fix: DateTime field space is not calculated correctly when default value MM/DD/YY on Edge and Firefox.