### PR TITLE
Input Placeholder i18n support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -56,6 +56,7 @@ limitations under the License.
         <p class="u-mb0">Event fired: <strong>px-datetime-submitted</strong></p>
         <p class="zeta u-mt0">See API Reference below for more details</p>
         <px-datetime-entry
+            resources="{{props.resources.value}}"
             block-future-dates="{{props.blockFutureDates.value}}"
             block-past-dates="{{props.blockPastDates.value}}"
             hide-icon="{{props.hideIcon.value}}"
@@ -126,6 +127,12 @@ limitations under the License.
      * A reference for `this.props`. Read the documentation there.
      */
     demoProps: {
+
+      resources: {
+        type: Object,
+        defaultValue: {"en":{"YY":"Year","MM":"Month","DD":"Day"}},
+        inputType: 'code:JSON'
+      },
 
       blockFutureDates: {
         type: Boolean,

--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -145,7 +145,8 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
     },
 
     observers:[
-      '_updateInputValue(momentObj, timeZone)'
+      '_updateInputValue(momentObj, timeZone)',
+      '_onResourcesUpdated(resources)'
     ],
 
     /**
@@ -284,6 +285,20 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
       }
     },
     /**
+     * When resources is changed, update placeholder text and resize input if need.
+     */
+    _onResourcesUpdated: function(resources) {
+      const entryInput = this.$$('.datetime-entry-input');
+      const currentPlaceholderText = entryInput.placeholder;
+      const nextPlaceholderText = this._placeholderText(this.momentFormat);
+      if (nextPlaceholderText !== currentPlaceholderText) {
+        entryInput.placeholder = nextPlaceholderText;
+        if (!this.momentObj) {
+          this._sizeInputs();
+        }
+      }
+    },
+    /**
      * Fires when 'left' key is hit
      *
      * @event px-entry-cell-move
@@ -412,6 +427,7 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
     },
     /**
      * If the momentFormat format is not 'Z', 'ZZ', 'X', 'x', 'A' or 'a' then return the momentFormat
+     * Note: placeholder text supports i18n
      */
     _placeholderText: function(momentFormat){
       var phText = {
@@ -423,10 +439,12 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
         'A': 'AM'
       };
 
+      let text = momentFormat;
+
       if(phText[momentFormat]){
-        return phText[momentFormat];
+        text = phText[momentFormat];
       }
-      return momentFormat;
+      return this.localize(text);
     },
      /**
      * Handles before copy event

--- a/test/px-datetime-entry-test-fixture.html
+++ b/test/px-datetime-entry-test-fixture.html
@@ -44,6 +44,7 @@ limitations under the License.
         date-or-time='Date'
         moment-format="YYYY/MM/DD Z"
         show-time-zone="dropdown"
+        resources='{"en":{"YYYY":"Year","MM":"Month","DD":"Day"}}'
         time-zone="UTC">
       </px-datetime-entry>
     </template>
@@ -65,6 +66,7 @@ limitations under the License.
       <px-datetime-entry
         date-or-time='Time'
         moment-format="hh:mm:ss.SSS A"
+        resources='{"en":{"hh":"Hour","mm":"Minute","ss":"Second"}}'
         show-time-zone="text">
       </px-datetime-entry>
     </template>

--- a/test/px-datetime-entry-tests.js
+++ b/test/px-datetime-entry-tests.js
@@ -34,6 +34,46 @@ suite('px-datetime-entry-cell', function () {
     });
   });
 
+  test('the date cells can have localized placeholder', function (done) {
+    const cells = Polymer.dom(dateFixt.root).querySelectorAll('px-datetime-entry-cell');
+    const yearInput = Polymer.dom(cells[0].root).querySelector('.datetime-entry-input');
+    const monthInput = Polymer.dom(cells[1].root).querySelector('.datetime-entry-input');
+    const dayInput = Polymer.dom(cells[2].root).querySelector('.datetime-entry-input');
+    expect(yearInput.getAttribute('placeholder')).to.equal('Year');
+    expect(monthInput.getAttribute('placeholder')).to.equal('Month');
+    expect(dayInput.getAttribute('placeholder')).to.equal('Day');
+    done();
+  });
+
+  test('the time cells can have localized placeholder', function (done) {
+    const cells = Polymer.dom(timeFixt.root).querySelectorAll('px-datetime-entry-cell');
+    const hourInput = Polymer.dom(cells[0].root).querySelector('.datetime-entry-input');
+    const minuteInput = Polymer.dom(cells[1].root).querySelector('.datetime-entry-input');
+    const secondInput = Polymer.dom(cells[2].root).querySelector('.datetime-entry-input');
+    expect(hourInput.getAttribute('placeholder')).to.equal('Hour');
+    expect(minuteInput.getAttribute('placeholder')).to.equal('Minute');
+    expect(secondInput.getAttribute('placeholder')).to.equal('Second');
+    done();
+  });
+
+  test('placeholder can get updated according to resources change', function(done) {
+    dateFixt.momentObj = null;
+    dateFixt.setAttribute('resources', JSON.stringify({
+      en: {
+        YYYY: 'Year2',
+        MM: 'Month2',
+        DD: 'Day2',
+      },
+    }));
+    const cells = Polymer.dom(dateFixt.root).querySelectorAll('px-datetime-entry-cell');
+    const yearInput = Polymer.dom(cells[0].root).querySelector('.datetime-entry-input');
+    const monthInput = Polymer.dom(cells[1].root).querySelector('.datetime-entry-input');
+    const dayInput = Polymer.dom(cells[2].root).querySelector('.datetime-entry-input');
+    expect(yearInput.getAttribute('placeholder')).to.equal('Year2');
+    expect(monthInput.getAttribute('placeholder')).to.equal('Month2');
+    expect(dayInput.getAttribute('placeholder')).to.equal('Day2');
+    done();
+  })
 
   test('the date cells have a value if momentObj is set', function (done) {
     var cells = Polymer.dom(dateFixt.root).querySelectorAll('px-datetime-entry-cell');
@@ -46,7 +86,7 @@ suite('px-datetime-entry-cell', function () {
 
 
   test('the time cells have a value if momentObj is set', function (done) {
-    var cells = Polymer.dom(timeEntry.root).querySelectorAll('px-datetime-entry-cell');
+    var cells = Polymer.dom(timeFixt.root).querySelectorAll('px-datetime-entry-cell');
     for (i = 0; i < cells.length; i++) {
       var cellInput = Polymer.dom(cells[i].root).querySelectorAll('.datetime-entry-input');
       assert.notEqual(cellInput[0].value, '');


### PR DESCRIPTION
From https://github.com/predixdesignsystem/px-datetime-picker/issues/38
* Add localization support to input placeholder.
* Add demo and test case.

@joshsylvester @evanjd @sheela-svmx @benjaminliugang pls help review. 
I haven't updated the version number due to previous discussion https://github.com/predixdesignsystem/px-spinner/pull/13#discussion_r261537745, @evanjd feel free to let me know if want me update the version as well in this PR.